### PR TITLE
feat: shared validation schemas with camelCase (#18)

### DIFF
--- a/apps/api/src/routes/events.ts
+++ b/apps/api/src/routes/events.ts
@@ -1,5 +1,6 @@
 import { Elysia, t } from "elysia";
 import { authMiddleware } from "../middleware/auth";
+import { createEventSchema, rsvpSchema, createPledgeSchema } from "@community-os/shared/validators";
 
 export const eventRoutes = new Elysia({ prefix: "/api/v1/events" })
   .use(authMiddleware)
@@ -31,6 +32,7 @@ export const eventRoutes = new Elysia({ prefix: "/api/v1/events" })
     },
     {
       auth: true,
+      body: createEventSchema,
       detail: { tags: ["Events"], summary: "Create event" },
     }
   )
@@ -42,6 +44,7 @@ export const eventRoutes = new Elysia({ prefix: "/api/v1/events" })
     },
     {
       auth: true,
+      body: rsvpSchema,
       detail: { tags: ["Events"], summary: "RSVP to event" },
     }
   )
@@ -64,6 +67,7 @@ export const eventRoutes = new Elysia({ prefix: "/api/v1/events" })
     },
     {
       auth: true,
+      body: createPledgeSchema,
       detail: { tags: ["Events"], summary: "Create pledge for event" },
     }
   );

--- a/apps/api/src/routes/events.ts
+++ b/apps/api/src/routes/events.ts
@@ -1,9 +1,10 @@
-import { Elysia, t } from "elysia";
+import { Elysia } from "elysia";
 import { authMiddleware } from "../middleware/auth";
-import { createEventSchema, rsvpSchema, createPledgeSchema } from "@community-os/shared/validators";
+import { eventModel } from "./models/event";
 
 export const eventRoutes = new Elysia({ prefix: "/api/v1/events" })
   .use(authMiddleware)
+  .use(eventModel)
   .get(
     "/",
     async () => {
@@ -32,7 +33,7 @@ export const eventRoutes = new Elysia({ prefix: "/api/v1/events" })
     },
     {
       auth: true,
-      body: createEventSchema,
+      body: "event.create",
       detail: { tags: ["Events"], summary: "Create event" },
     }
   )
@@ -44,7 +45,7 @@ export const eventRoutes = new Elysia({ prefix: "/api/v1/events" })
     },
     {
       auth: true,
-      body: rsvpSchema,
+      body: "event.rsvp",
       detail: { tags: ["Events"], summary: "RSVP to event" },
     }
   )
@@ -67,7 +68,7 @@ export const eventRoutes = new Elysia({ prefix: "/api/v1/events" })
     },
     {
       auth: true,
-      body: createPledgeSchema,
+      body: "event.pledge.create",
       detail: { tags: ["Events"], summary: "Create pledge for event" },
     }
   );

--- a/apps/api/src/routes/funds.ts
+++ b/apps/api/src/routes/funds.ts
@@ -1,9 +1,10 @@
 import { Elysia } from "elysia";
 import { authMiddleware } from "../middleware/auth";
-import { createTransactionSchema } from "@community-os/shared/validators";
+import { fundModel } from "./models/fund";
 
 export const fundRoutes = new Elysia({ prefix: "/api/v1/funds" })
   .use(authMiddleware)
+  .use(fundModel)
   .get(
     "/overview",
     async () => {
@@ -45,7 +46,7 @@ export const fundRoutes = new Elysia({ prefix: "/api/v1/funds" })
     },
     {
       auth: true,
-      body: createTransactionSchema,
+      body: "fund.transaction.create",
       detail: { tags: ["Funds"], summary: "Create transaction" },
     }
   );

--- a/apps/api/src/routes/funds.ts
+++ b/apps/api/src/routes/funds.ts
@@ -1,5 +1,6 @@
 import { Elysia } from "elysia";
 import { authMiddleware } from "../middleware/auth";
+import { createTransactionSchema } from "@community-os/shared/validators";
 
 export const fundRoutes = new Elysia({ prefix: "/api/v1/funds" })
   .use(authMiddleware)
@@ -44,6 +45,7 @@ export const fundRoutes = new Elysia({ prefix: "/api/v1/funds" })
     },
     {
       auth: true,
+      body: createTransactionSchema,
       detail: { tags: ["Funds"], summary: "Create transaction" },
     }
   );

--- a/apps/api/src/routes/members.ts
+++ b/apps/api/src/routes/members.ts
@@ -1,12 +1,13 @@
-import { Elysia, t } from "elysia";
+import { Elysia } from "elysia";
 import { authMiddleware } from "../middleware/auth";
 import { db } from "../db";
 import { members } from "../db/schema";
 import { eq } from "drizzle-orm";
-import { updateMemberSchema } from "@community-os/shared/validators";
+import { memberModel } from "./models/member";
 
 export const memberRoutes = new Elysia({ prefix: "/api/v1/members" })
   .use(authMiddleware)
+  .use(memberModel)
   .get(
     "/me",
     async ({ user }) => {
@@ -32,7 +33,7 @@ export const memberRoutes = new Elysia({ prefix: "/api/v1/members" })
     },
     {
       auth: true,
-      body: updateMemberSchema,
+      body: "member.update",
       detail: { tags: ["Members"], summary: "Update current member profile" },
     }
   )

--- a/apps/api/src/routes/members.ts
+++ b/apps/api/src/routes/members.ts
@@ -3,6 +3,7 @@ import { authMiddleware } from "../middleware/auth";
 import { db } from "../db";
 import { members } from "../db/schema";
 import { eq } from "drizzle-orm";
+import { updateMemberSchema } from "@community-os/shared/validators";
 
 export const memberRoutes = new Elysia({ prefix: "/api/v1/members" })
   .use(authMiddleware)
@@ -31,21 +32,7 @@ export const memberRoutes = new Elysia({ prefix: "/api/v1/members" })
     },
     {
       auth: true,
-      body: t.Partial(
-        t.Object({
-          telegram_username: t.String(),
-          github_handle: t.String(),
-          phone_number: t.String(),
-          bio: t.String(),
-          skills: t.Array(t.String()),
-          interests: t.Array(t.String()),
-          current_company: t.String(),
-          current_title: t.String(),
-          education: t.String(),
-          linkedin_url: t.String(),
-          website_url: t.String(),
-        })
-      ),
+      body: updateMemberSchema,
       detail: { tags: ["Members"], summary: "Update current member profile" },
     }
   )

--- a/apps/api/src/routes/models/event.ts
+++ b/apps/api/src/routes/models/event.ts
@@ -1,0 +1,12 @@
+import { Elysia } from "elysia";
+import {
+  createEventSchema,
+  rsvpSchema,
+  createPledgeSchema,
+} from "@community-os/shared/validators";
+
+export const eventModel = new Elysia({ name: "model.event" }).model({
+  "event.create": createEventSchema,
+  "event.rsvp": rsvpSchema,
+  "event.pledge.create": createPledgeSchema,
+});

--- a/apps/api/src/routes/models/fund.ts
+++ b/apps/api/src/routes/models/fund.ts
@@ -1,0 +1,6 @@
+import { Elysia } from "elysia";
+import { createTransactionSchema } from "@community-os/shared/validators";
+
+export const fundModel = new Elysia({ name: "model.fund" }).model({
+  "fund.transaction.create": createTransactionSchema,
+});

--- a/apps/api/src/routes/models/member.ts
+++ b/apps/api/src/routes/models/member.ts
@@ -1,0 +1,6 @@
+import { Elysia } from "elysia";
+import { updateMemberSchema } from "@community-os/shared/validators";
+
+export const memberModel = new Elysia({ name: "model.member" }).model({
+  "member.update": updateMemberSchema,
+});

--- a/apps/api/src/routes/models/project.ts
+++ b/apps/api/src/routes/models/project.ts
@@ -1,0 +1,10 @@
+import { Elysia } from "elysia";
+import {
+  createProjectSchema,
+  addProjectMemberSchema,
+} from "@community-os/shared/validators";
+
+export const projectModel = new Elysia({ name: "model.project" }).model({
+  "project.create": createProjectSchema,
+  "project.member.add": addProjectMemberSchema,
+});

--- a/apps/api/src/routes/models/reputation.ts
+++ b/apps/api/src/routes/models/reputation.ts
@@ -1,0 +1,6 @@
+import { Elysia } from "elysia";
+import { createReputationEventSchema } from "@community-os/shared/validators";
+
+export const reputationModel = new Elysia({ name: "model.reputation" }).model({
+  "reputation.event.create": createReputationEventSchema,
+});

--- a/apps/api/src/routes/projects.ts
+++ b/apps/api/src/routes/projects.ts
@@ -1,6 +1,7 @@
 import { Elysia } from "elysia";
 import { authMiddleware } from "../middleware/auth";
 import { projects } from "../db/schema/projects";
+import { createProjectSchema, addProjectMemberSchema } from "@community-os/shared/validators";
 
 type Project = typeof projects.$inferSelect;
 
@@ -34,6 +35,7 @@ export const projectRoutes = new Elysia({ prefix: "/api/v1/projects" })
     },
     {
       auth: true,
+      body: createProjectSchema,
       detail: { tags: ["Projects"], summary: "Create project" },
     }
   )
@@ -45,6 +47,7 @@ export const projectRoutes = new Elysia({ prefix: "/api/v1/projects" })
     },
     {
       auth: true,
+      body: addProjectMemberSchema,
       detail: { tags: ["Projects"], summary: "Add project member" },
     }
   )

--- a/apps/api/src/routes/projects.ts
+++ b/apps/api/src/routes/projects.ts
@@ -1,12 +1,13 @@
 import { Elysia } from "elysia";
 import { authMiddleware } from "../middleware/auth";
 import { projects } from "../db/schema/projects";
-import { createProjectSchema, addProjectMemberSchema } from "@community-os/shared/validators";
+import { projectModel } from "./models/project";
 
 type Project = typeof projects.$inferSelect;
 
 export const projectRoutes = new Elysia({ prefix: "/api/v1/projects" })
   .use(authMiddleware)
+  .use(projectModel)
   .get(
     "/",
     async () => {
@@ -35,7 +36,7 @@ export const projectRoutes = new Elysia({ prefix: "/api/v1/projects" })
     },
     {
       auth: true,
-      body: createProjectSchema,
+      body: "project.create",
       detail: { tags: ["Projects"], summary: "Create project" },
     }
   )
@@ -47,7 +48,7 @@ export const projectRoutes = new Elysia({ prefix: "/api/v1/projects" })
     },
     {
       auth: true,
-      body: addProjectMemberSchema,
+      body: "project.member.add",
       detail: { tags: ["Projects"], summary: "Add project member" },
     }
   )

--- a/apps/api/src/routes/reputation.ts
+++ b/apps/api/src/routes/reputation.ts
@@ -1,9 +1,10 @@
 import { Elysia } from "elysia";
 import { authMiddleware } from "../middleware/auth";
-import { createReputationEventSchema } from "@community-os/shared/validators";
+import { reputationModel } from "./models/reputation";
 
 export const reputationRoutes = new Elysia({ prefix: "/api/v1/reputation" })
   .use(authMiddleware)
+  .use(reputationModel)
   .get(
     "/:userId",
     async ({ params: { userId } }) => {
@@ -32,7 +33,7 @@ export const reputationRoutes = new Elysia({ prefix: "/api/v1/reputation" })
     },
     {
       auth: true,
-      body: createReputationEventSchema,
+      body: "reputation.event.create",
       detail: { tags: ["Reputation"], summary: "Record reputation event" },
     }
   );

--- a/apps/api/src/routes/reputation.ts
+++ b/apps/api/src/routes/reputation.ts
@@ -1,5 +1,6 @@
 import { Elysia } from "elysia";
 import { authMiddleware } from "../middleware/auth";
+import { createReputationEventSchema } from "@community-os/shared/validators";
 
 export const reputationRoutes = new Elysia({ prefix: "/api/v1/reputation" })
   .use(authMiddleware)
@@ -31,6 +32,7 @@ export const reputationRoutes = new Elysia({ prefix: "/api/v1/reputation" })
     },
     {
       auth: true,
+      body: createReputationEventSchema,
       detail: { tags: ["Reputation"], summary: "Record reputation event" },
     }
   );

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -43,3 +43,5 @@ export type {
   CreateReputationEventInput,
   CreateReputationTriggerInput,
 } from "../validators/reputation";
+
+export type { PaginationInput } from "../validators/common";

--- a/packages/shared/src/validators/common.ts
+++ b/packages/shared/src/validators/common.ts
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const paginationSchema = z.object({
+  page: z.coerce.number().int().positive().default(1),
+  limit: z.coerce.number().int().positive().max(100).default(20),
+});
+
+export type PaginationInput = z.infer<typeof paginationSchema>;

--- a/packages/shared/src/validators/events.ts
+++ b/packages/shared/src/validators/events.ts
@@ -9,14 +9,14 @@ import {
 export const createEventSchema = z.object({
   title: z.string().min(1).max(200),
   description: z.string().optional(),
-  event_type: z.enum(EVENT_TYPES),
-  venue_id: z.string().uuid().optional(),
-  is_online: z.boolean().default(false),
-  online_url: z.string().url().optional(),
-  starts_at: z.string().datetime(),
-  ends_at: z.string().datetime().optional(),
-  max_attendees: z.number().int().positive().optional(),
-  budget_target: z.number().positive().optional(),
+  eventType: z.enum(EVENT_TYPES),
+  venueId: z.string().uuid().optional(),
+  isOnline: z.boolean().default(false),
+  onlineUrl: z.string().url().optional(),
+  startsAt: z.string().datetime(),
+  endsAt: z.string().datetime().optional(),
+  maxAttendees: z.number().int().positive().optional(),
+  budgetTarget: z.number().positive().optional(),
 });
 
 export const updateEventSchema = createEventSchema.partial().extend({
@@ -24,7 +24,7 @@ export const updateEventSchema = createEventSchema.partial().extend({
 });
 
 export const rsvpSchema = z.object({
-  rsvp_status: z.enum(RSVP_STATUSES),
+  rsvpStatus: z.enum(RSVP_STATUSES),
 });
 
 export const createPledgeSchema = z.object({

--- a/packages/shared/src/validators/funds.ts
+++ b/packages/shared/src/validators/funds.ts
@@ -6,14 +6,14 @@ export const createTransactionSchema = z.object({
   amount: z.number().positive(),
   currency: z.string().default("SGD"),
   description: z.string().min(1),
-  category_id: z.string().uuid(),
-  reference_type: z.enum(["event", "project", "provisioned_resource"]).optional(),
-  reference_id: z.string().uuid().optional(),
-  pledge_id: z.string().uuid().optional(),
-  paid_by: z.string().optional(),
-  received_by: z.string().optional(),
-  receipt_url: z.string().url().optional(),
-  occurred_at: z.string().datetime(),
+  categoryId: z.string().uuid(),
+  referenceType: z.enum(["event", "project", "provisioned_resource"]).optional(),
+  referenceId: z.string().uuid().optional(),
+  pledgeId: z.string().uuid().optional(),
+  paidBy: z.string().optional(),
+  receivedBy: z.string().optional(),
+  receiptUrl: z.string().url().optional(),
+  occurredAt: z.string().datetime(),
 });
 
 export const updateTransactionSchema = createTransactionSchema.partial();

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -1,3 +1,4 @@
+export * from "./common";
 export * from "./members";
 export * from "./events";
 export * from "./projects";

--- a/packages/shared/src/validators/members.ts
+++ b/packages/shared/src/validators/members.ts
@@ -1,17 +1,17 @@
 import { z } from "zod";
 
 export const updateMemberSchema = z.object({
-  telegram_username: z.string().optional(),
-  github_handle: z.string().optional(),
-  phone_number: z.string().optional(),
+  telegramUsername: z.string().optional(),
+  githubHandle: z.string().optional(),
+  phoneNumber: z.string().optional(),
   bio: z.string().max(500).optional(),
   skills: z.array(z.string()).optional(),
   interests: z.array(z.string()).optional(),
-  current_company: z.string().optional(),
-  current_title: z.string().optional(),
+  currentCompany: z.string().optional(),
+  currentTitle: z.string().optional(),
   education: z.string().optional(),
-  linkedin_url: z.string().url().optional(),
-  website_url: z.string().url().optional(),
+  linkedinUrl: z.string().url().optional(),
+  websiteUrl: z.string().url().optional(),
 });
 
 export type UpdateMemberInput = z.infer<typeof updateMemberSchema>;

--- a/packages/shared/src/validators/projects.ts
+++ b/packages/shared/src/validators/projects.ts
@@ -12,8 +12,8 @@ export const createProjectSchema = z.object({
   nature: z.enum(PROJECT_NATURES),
   platforms: z.array(z.enum(PROJECT_PLATFORMS)).default([]),
   url: z.string().url().optional(),
-  repo_url: z.string().url().optional(),
-  thumbnail_url: z.string().url().optional(),
+  repoUrl: z.string().url().optional(),
+  thumbnailUrl: z.string().url().optional(),
 });
 
 export const updateProjectSchema = createProjectSchema.partial().extend({
@@ -21,7 +21,7 @@ export const updateProjectSchema = createProjectSchema.partial().extend({
 });
 
 export const addProjectMemberSchema = z.object({
-  user_id: z.string(),
+  userId: z.string(),
   role: z.enum(PROJECT_MEMBER_ROLES),
 });
 

--- a/packages/shared/src/validators/reputation.ts
+++ b/packages/shared/src/validators/reputation.ts
@@ -2,19 +2,19 @@ import { z } from "zod";
 import { REPUTATION_TRIGGER_TYPES } from "../constants";
 
 export const createReputationEventSchema = z.object({
-  from_user_id: z.string(),
-  to_user_id: z.string(),
-  trigger_id: z.string().uuid(),
+  fromUserId: z.string(),
+  toUserId: z.string(),
+  triggerId: z.string().uuid(),
   value: z.number().int(),
-  telegram_message_id: z.string().optional(),
-  telegram_chat_id: z.string().optional(),
+  telegramMessageId: z.string().optional(),
+  telegramChatId: z.string().optional(),
 });
 
 export const createReputationTriggerSchema = z.object({
-  trigger_type: z.enum(REPUTATION_TRIGGER_TYPES),
-  trigger_value: z.string().min(1),
-  reputation_value: z.number().int(),
-  is_active: z.boolean().default(true),
+  triggerType: z.enum(REPUTATION_TRIGGER_TYPES),
+  triggerValue: z.string().min(1),
+  reputationValue: z.number().int(),
+  isActive: z.boolean().default(true),
 });
 
 export type CreateReputationEventInput = z.infer<typeof createReputationEventSchema>;


### PR DESCRIPTION
## Summary
- Convert all 5 validator files from snake_case to camelCase (matching Drizzle ORM property names)
- Add `paginationSchema` in new `common.ts` validator
- Wire Zod schemas into API route `body:` validation via Elysia's StandardSchema support
- Replace inline TypeBox validation in members route with shared Zod schema
- Update shared type exports with `PaginationInput`

## Test plan
- [ ] `bun type-check` passes across workspace
- [ ] POST to `/api/v1/events` with empty body returns 400 validation error
- [ ] POST with valid camelCase body passes validation
- [ ] OpenAPI docs show request body schemas

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)